### PR TITLE
Add serializability

### DIFF
--- a/pyoctree/Examples/pickle_test.py
+++ b/pyoctree/Examples/pickle_test.py
@@ -1,0 +1,12 @@
+import pickle
+
+import numpy as np
+from pyoctree import pyoctree
+
+vertices = np.array(((0, 0, 0), (1, 1, 1), (2, 0, 0)), dtype=float)
+polygons = np.array(((0, 1, 2),), dtype=int)
+
+tree = pyoctree.PyOctree(vertices, polygons)
+
+tree_data = pickle.dumps(tree)
+tree_new = pickle.loads(tree_data)

--- a/pyoctree/cOctree.cpp
+++ b/pyoctree/cOctree.cpp
@@ -333,6 +333,11 @@ bool cOctNode::boxRayIntersect(cLine &ray)
 
 // ------------------------------------------------------
 
+cOctree::cOctree()
+{
+    // Default cOctree constructor
+}
+
 
 cOctree::cOctree(vector<vector<double> > _vertexCoords3D, vector<vector<int> > _polyConnectivity)
 {

--- a/pyoctree/cOctree.h
+++ b/pyoctree/cOctree.h
@@ -99,7 +99,8 @@ public:
     vector<vector<int> > polyConnectivity;
     vector<cTri> polyList;
     cOctree(vector<vector<double> > _vertexCoords3D, vector<vector<int> > _polyConnectivity);
-    ~cOctree();    
+    cOctree();
+    ~cOctree();
     double getSizeRoot();
     int numPolys();
     cOctNode* getNodeFromId(string nodeId);

--- a/pyoctree/pyoctree.pyx
+++ b/pyoctree/pyoctree.pyx
@@ -132,11 +132,7 @@ cdef class PyOctree:
 
     def __getstate__(self):
         # make class serializable with pickle
-        # 'polyList' is not necessary for __setstate__ but complements the representation of the tree in the dict
-        pickle_dict = {'root': self.root.__getstate__(),
-                       'polyList': [poly.__getstate__() for poly in self.polyList],
-                       'thisptr': self.__serialize_cOctree__(self.thisptr),
-                       }
+        pickle_dict = {'thisptr': self.__serialize_cOctree__(self.thisptr)}
         return pickle_dict
 
     def __setstate__(self, state):
@@ -673,13 +669,9 @@ cdef class PyTri:
 cdef __serialize_cTri__(cTri ctri):
     return {'D': ctri.D,
             'label': ctri.label,
-            # 'vertices': [ctri.vertices[i][j] for j in range(3) for i in range(int(ctri.vertices.size()))],
             'vertices': ctri.vertices,
-            # 'N': [ctri.N[i] for i in range(int(ctri.N.size()))],
             'N': ctri.N,
-            # 'lowVert': [ctri.lowVert[i] for i in range(int(ctri.lowVert.size()))],
             'lowVert': ctri.lowVert,
-            # 'uppVert': [ctri.uppVert[i] for i in range(int(ctri.uppVert.size()))],
             'uppVert': ctri.uppVert,
             }
 

--- a/pyoctree/pyoctree.pyx
+++ b/pyoctree/pyoctree.pyx
@@ -667,24 +667,11 @@ cdef class PyTri:
 
 
 cdef __serialize_cTri__(cTri ctri):
-    return {'D': ctri.D,
-            'label': ctri.label,
-            'vertices': ctri.vertices,
-            'N': ctri.N,
-            'lowVert': ctri.lowVert,
-            'uppVert': ctri.uppVert,
-            }
+    return {'label': ctri.label,
+            'vertices': ctri.vertices}
 
 cdef cTri * __deserialize_cTri__(state: dict):
-    cdef cTri *ctri = new cTri()
-
-    ctri.D = state['D']
-    ctri.label = state['label']
-    ctri.vertices = state['vertices']
-    ctri.N = state['N']
-    ctri.lowVert = state['lowVert']
-    ctri.uppVert = state['uppVert']
-
+    cdef cTri *ctri = new cTri(state['label'], state['vertices'])
     return ctri
 
 # Need a global function to be able to point a cOctNode to a PyOctnode

--- a/pyoctree/pyoctree.pyx
+++ b/pyoctree/pyoctree.pyx
@@ -53,6 +53,7 @@ cdef extern from "cOctree.h":
         vector[double] low
         vector[double] upp
         cOctNode()   
+        cOctNode(int _level, string _nid, vector[double] _position, double _size)
         int numPolys()
         bint isLeafNode()
         bint boxRayIntersect(cLine &ray)
@@ -432,26 +433,16 @@ cdef class PyOctnode:
                 'position': c_octnode.position,
                 'branches': [self.__serialize_cOctNode__(&c_octnode.branches[i]) for i in range(int(c_octnode.branches.size()))],
                 'data': c_octnode.data,
-                'low': c_octnode.low,
-                'upp': c_octnode.upp,
                 }
 
     cdef cOctNode * __deserialize_cOctNode__(self, state: dict):
-        cdef cOctNode *c_octnode = new cOctNode()
+        cdef cOctNode *c_octnode = new cOctNode(state['level'], state['nid'], state['position'], state['size'])
         cdef vector[cOctNode] branches
-        cdef vector[double] low
-        cdef vector[double] upp
 
-        c_octnode.size = state['size']
-        c_octnode.level = state['level']
-        c_octnode.nid = state['nid']
-        c_octnode.position = state['position']
         for cOctNode_dict in state['branches']:
             branches.push_back(deref(self.__deserialize_cOctNode__(cOctNode_dict)))
         c_octnode.branches = branches
         c_octnode.data = state['data']
-        c_octnode.low = state['low']
-        c_octnode.upp = state['upp']
 
         return c_octnode
         

--- a/pyoctree/pyoctree.pyx
+++ b/pyoctree/pyoctree.pyx
@@ -74,6 +74,7 @@ cdef extern from "cOctree.h":
         vector[bint] findRayIntersectsSorted(vector[cLine] &rayList)
         set[int] getListPolysToCheck(cLine &ray)
         vector[cOctNode*] getSortedNodesToCheck(cLine &ray)
+        void setupPolyList()
     
     
 cdef class PyOctree:
@@ -142,10 +143,11 @@ cdef class PyOctree:
         self.__update_root_polyList()
 
     cdef __serialize_cOctree__(self, cOctree *c_octree):
+        cdef int n_polygons = c_octree.polyList.size()
+
         return {'root': PyOctnode.__serialize_cOctNode__(self.root, &c_octree.root),
                 'vertexCoords3D': c_octree.vertexCoords3D,
                 'polyConnectivity': c_octree.polyConnectivity,
-                'polyList': [__serialize_cTri__(c_octree.polyList[i]) for i in range(int(c_octree.polyList.size()))],
                 }
 
     cdef cOctree * __deserialize_cOctree__(self, state: dict):
@@ -155,9 +157,7 @@ cdef class PyOctree:
         c_octree.root = deref(PyOctnode().__deserialize_cOctNode__(state['root']))
         c_octree.vertexCoords3D = state['vertexCoords3D']
         c_octree.polyConnectivity = state['polyConnectivity']
-        for cTri_dict in state['polyList']:
-            polyList.push_back(deref(__deserialize_cTri__(cTri_dict)))
-        c_octree.polyList = polyList
+        c_octree.setupPolyList()
 
         return c_octree
 

--- a/pyoctree/version.py
+++ b/pyoctree/version.py
@@ -5,4 +5,4 @@
 # This file is part of pyoctree - See LICENSE.txt for information on usage and redistribution
 
 # Version
-__version__ = '0.2.10'
+__version__ = '0.2.11'


### PR DESCRIPTION
Add the option to serialize the cOctree and restore it, this enables multiprocessing with python. 
Joblib and multiprocessing serialize objects using pickle and restoring a copy of them in each process.

This speeds up my programs by a factor of ~5 for a tree with ~160k triangles and 17k nodes.

Fixes https://github.com/mhogg/pyoctree/issues/34 